### PR TITLE
Load data from an URL instead of a local file

### DIFF
--- a/video_game_data.livemd
+++ b/video_game_data.livemd
@@ -11,7 +11,8 @@ Mix.install(
     {:kino_vega_lite, "~> 0.1.8"},
     {:scholar, "~> 0.1.0"},
     {:jason, "~> 1.4.0"},
-    {:exla, "~> 0.5.2"}
+    {:exla, "~> 0.5.2"},
+    {:req, "~> 0.3.6"}
   ],
   config: [
     nx: [default_backend: EXLA.Backend],
@@ -37,7 +38,14 @@ require Explorer.Series, as: Series
 ## Read in the Data
 
 ```elixir
-df = DF.from_csv!("~/Documents/Video_Games_Sales_as_at_22_Dec_2016.csv")
+csv =
+  Req.get!(
+    "https://raw.githubusercontent.com/danieljaouen/DS-Unit-1-Sprint-1-Dealing-With-Data/master/module1-afirstlookatdata/Video_Games_Sales_as_at_22_Dec_2016.csv"
+  ).body
+```
+
+```elixir
+df = DF.load_csv!(csv)
 DF.head(df)
 ```
 


### PR DESCRIPTION
This PR can make the notebook easier to reproduce by others, as they would not need to first download the file with the data, they can just run the notebook.